### PR TITLE
add Home page content

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -56,15 +56,7 @@
     {{> Banner}}
 
     <main id=main class=main>
-
-      <h1>Lotus</h1>
-
-      <h2>Coming soon!</h2>
-
-      <p>The Lotus app is a tool for linguists to manage their linguistic data, including lexicons, texts, and cognate sets. Keep checking back for updates!</p>
-      <p><a href=https://digitallinguistics.io>Learn more about the Digital Linguistics project here!</a></p>
-      <p><a href=https://twitter.com/digitalling>Follow Digital Linguistics on Twitter!</a></p>
-
+      {{> Home}}
     </main>
 
   </body>

--- a/src/pages/Home/Home.html
+++ b/src/pages/Home/Home.html
@@ -1,0 +1,7 @@
+<h1>Lotus</h1>
+
+<h2>Coming soon!</h2>
+
+<p>The Lotus app is a tool for linguists to manage their linguistic data, including lexicons, texts, and cognate sets. Keep checking back for updates!</p>
+<p><a href=https://digitallinguistics.io>Learn more about the Digital Linguistics project here!</a></p>
+<p><a href=https://twitter.com/digitalling>Follow Digital Linguistics on Twitter!</a></p>


### PR DESCRIPTION
This PR moves the content for the Home page into the `pages/Home` directory, and includes that content in the app shell when it loads. Partially addresses #51 (also need to address #62 and #52 to finish #51).