### PR TITLE
add docs about rendering pages

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -116,7 +116,7 @@ Folder          | Description
 
 ## Pages & Components
 
-The code for the app consists of the app shell, plus one bundle of code for each page within the app. The HTML, CSS, and JavaScript for each page are loaded dynamically when that page is loaded. (These files are cached by a service worker in advance, so the user doesn't have to wait for them to be fetched from the server.) So all of the various code and components for the Languages page, for example, are compiled into the following three files:
+The code for the app consists of the app shell, plus one bundle of code for each page within the app. The HTML, CSS, and JavaScript for each page are loaded dynamically when that page is loaded. (These files are cached by a service worker in advance, so the user doesn't have to wait for them to be fetched from the server.) All of the various code and components for the Languages page, for example, are compiled into the following three files:
 
 * `Languages.html`
 * `Languages.css`
@@ -137,11 +137,19 @@ pages/
 * Components that are specific to the app shell should be placed in the `App/` folder instead of a page folder.
 * Components that are used across pages should be placed in the `components/` folder instead of a page folder.
 
-The HTML build step will insert each component's HTML into a `<template id={component-name}-template>` tag in that page's HTML (or the app shell, if the component is shared across pages). Your JavaScript component should load that template using `document.querySelector('#{component-name}-template')`.
+The HTML build step will insert each component's HTML into a `<template id={component-name}-template>` tag in that page's HTML (or the app shell, if the component is shared across pages). Your JavaScript component can load that template using `document.querySelector('#{component-name}-template')`.
 
 The CSS for each component will be loaded along with the page's CSS.
 
 Each page's JavaScript is responsible for loading its own components, and they in turn are responsible for loading any subcomponents.
+
+## Rendering Pages & Components
+
+Pages and components should never insert themselves into the DOM; this is the job of their controller. The `render()` method of each View instance should update the `el` property of the instance with the new DOM element, and return that element.
+
+Each page or component should return a single root element. Pages must always return a `<main id={page}>` element.
+
+Pages and controllers _should_ add their own event listeners. This can be done at the end of the `render()` method.
 
 ## Images
 

--- a/src/index.html
+++ b/src/index.html
@@ -52,12 +52,11 @@
     {{!-- skip link --}}
     <a href=#main class=skip-link>Skip to main content</a>
 
-    {{!-- The main banner for the app, containing the app logo and high-level app controls --}}
+    {{!-- the main banner for the app, containing the app logo and high-level app controls --}}
     {{> Banner}}
 
-    <main id=main class=main>
-      {{> Home}}
-    </main>
+    {{!-- the main content of the page (should always be a `<main id={page}>` element --}}
+    {{> Home}}
 
   </body>
 
@@ -67,10 +66,10 @@
   {{!-- SVG sprites, which can be reused across the app with the <use> tag --}}
   {{> sprites}}
 
-  {{!-- App-level scripts go here --}}
+  {{!-- app-level scripts go here --}}
   <script>
 
-    // Register the offline service worker
+    // register the offline service worker
     if ('serviceWorker' in navigator && navigator.onLine) {
       navigator.serviceWorker.register('offline-worker.js');
     }

--- a/src/pages/Home/Home.html
+++ b/src/pages/Home/Home.html
@@ -1,7 +1,11 @@
-<h1>Lotus</h1>
+<main id=home>
 
-<h2>Coming soon!</h2>
+  <h1>Lotus</h1>
 
-<p>The Lotus app is a tool for linguists to manage their linguistic data, including lexicons, texts, and cognate sets. Keep checking back for updates!</p>
-<p><a href=https://digitallinguistics.io>Learn more about the Digital Linguistics project here!</a></p>
-<p><a href=https://twitter.com/digitalling>Follow Digital Linguistics on Twitter!</a></p>
+  <h2>Coming soon!</h2>
+
+  <p>The Lotus app is a tool for linguists to manage their linguistic data, including lexicons, texts, and cognate sets. Keep checking back for updates!</p>
+  <p><a href=https://digitallinguistics.io>Learn more about the Digital Linguistics project here!</a></p>
+  <p><a href=https://twitter.com/digitalling>Follow Digital Linguistics on Twitter!</a></p>
+
+</main>


### PR DESCRIPTION
In lieu of adding a Page View (see #52), this PR adds documentation clarifying how View instances should be coded and rendered.

closes #52 (won't do)