### PR TITLE
pages

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -116,7 +116,7 @@ Folder          | Description
 
 ## Pages & Components
 
-The code for the app consists of the app shell, plus one bundle of code for each page within the app. The HTML, CSS, and JavaScript for each page are loaded dynamically when that page is loaded. (These files are cached by a service worker in advance, so the user doesn't have to wait for them to be fetched from the server.) So all of the various code and components for the Languages page, for example, are compiled into the following three files:
+The code for the app consists of the app shell, plus one bundle of code for each page within the app. The HTML, CSS, and JavaScript for each page are loaded dynamically when that page is loaded. (These files are cached by a service worker in advance, so the user doesn't have to wait for them to be fetched from the server.) All of the various code and components for the Languages page, for example, are compiled into the following three files:
 
 * `Languages.html`
 * `Languages.css`
@@ -137,11 +137,19 @@ pages/
 * Components that are specific to the app shell should be placed in the `App/` folder instead of a page folder.
 * Components that are used across pages should be placed in the `components/` folder instead of a page folder.
 
-The HTML build step will insert each component's HTML into a `<template id={component-name}-template>` tag in that page's HTML (or the app shell, if the component is shared across pages). Your JavaScript component should load that template using `document.querySelector('#{component-name}-template')`.
+The HTML build step will insert each component's HTML into a `<template id={component-name}-template>` tag in that page's HTML (or the app shell, if the component is shared across pages). Your JavaScript component can load that template using `document.querySelector('#{component-name}-template')`.
 
 The CSS for each component will be loaded along with the page's CSS.
 
 Each page's JavaScript is responsible for loading its own components, and they in turn are responsible for loading any subcomponents.
+
+## Rendering Pages & Components
+
+Pages and components should never insert themselves into the DOM; this is the job of their controller. The `render()` method of each View instance should update the `el` property of the instance with the new DOM element, and return that element.
+
+Each page or component should return a single root element. Pages must always return a `<main id={page}>` element.
+
+Pages and controllers _should_ add their own event listeners. This can be done at the end of the `render()` method.
 
 ## Images
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -24,6 +24,7 @@ Want to contribute code to the Lotus app? Awesome! 🌟 Check out [GitHub's Open
 - [App Structure](#app-structure)
 - [Directory Structure](#directory-structure)
 - [Pages & Components](#pages--components)
+- [Rendering Pages & Components](#rendering-pages--components)
 - [Images](#images)
 - [Offline Functionality](#offline-functionality)
 - [Styleguides](#styleguides)
@@ -144,6 +145,8 @@ The CSS for each component will be loaded along with the page's CSS.
 Each page's JavaScript is responsible for loading its own components, and they in turn are responsible for loading any subcomponents.
 
 ## Rendering Pages & Components
+
+Each page and component should be an instance of the `View` class. This class is made available as a global variable (`window.View`) when the `App.js` script loads.
 
 Pages and components should never insert themselves into the DOM; this is the job of their controller. The `render()` method of each View instance should update the `el` property of the instance with the new DOM element, and return that element.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -147,7 +147,7 @@ Each page's JavaScript is responsible for loading its own components, and they i
 
 Pages and components should never insert themselves into the DOM; this is the job of their controller. The `render()` method of each View instance should update the `el` property of the instance with the new DOM element, and return that element.
 
-Each page or component should return a single root element. Pages must always return a `<main id={page}>` element.
+Each page or component should return a single root element. Pages must always return a `<main id={page}-page>` element.
 
 Pages and controllers _should_ add their own event listeners. This can be done at the end of the `render()` method.
 

--- a/build/buildCache.js
+++ b/build/buildCache.js
@@ -41,8 +41,6 @@ export default async function buildCache() {
 
   }
 
-  const json = JSON.stringify(assets, null, 2);
-
-  await writeJSON(cachePath, json);
+  await writeJSON(cachePath, assets, { spaces: 2 });
 
 }

--- a/build/buildHTML.js
+++ b/build/buildHTML.js
@@ -19,11 +19,30 @@ const {
 const currentDir = getDirname(fileURLToPath(import.meta.url));
 const srcDir     = joinPath(currentDir, `../src`);
 const distDir    = joinPath(currentDir, `../dist`);
+const pagesDir   = joinPath(srcDir, `pages`);
 
 async function generateCriticalCSS() {
   const appShellStylesPath      = joinPath(currentDir, `../src/index.less`);
   const appShellSASS            = await readFile(appShellStylesPath, `utf8`);
   return convertLESS(appShellSASS);
+}
+
+/**
+ * Builds the HTML for a single page, given an file entry returned [readdirp](https://www.npmjs.com/package/readdirp).
+ * @param {Object} entry An entry from the [readdirp](https://www.npmjs.com/package/readdirp) package.
+ */
+async function buildPageHTML(entry) {
+
+  const ext = getExt(entry.basename);
+
+  if (ext !== `.html`) return;
+
+  const pageTemplate = await readFile(entry.fullPath, `utf8`);
+  const buildPage    = hbs.compile(pageTemplate);
+  const pageHTML     = buildPage();
+
+  await outputFile(joinPath(distDir, `pages`, entry.path), pageHTML);
+
 }
 
 /**
@@ -66,13 +85,20 @@ export default async function buildHTML() {
   await registerPartialsDir(joinPath(srcDir, `App`));
 
   // register page partials
-  await registerPartialsDir(joinPath(srcDir, `pages`));
+  await registerPartialsDir(pagesDir);
 
   // build the app shell
   const appTemplate = await readFile(joinPath(srcDir, `index.html`), `utf8`);
   const buildApp    = hbs.compile(appTemplate);
-  const app         = buildApp();
+  const appHTML     = buildApp();
 
-  await outputFile(joinPath(distDir, `index.html`), app);
+  await outputFile(joinPath(distDir, `index.html`), appHTML);
+
+  // build the HTML for individual pages
+  const pages = await recurse(pagesDir);
+
+  for await (const entry of pages) {
+    await buildPageHTML(entry);
+  }
 
 }

--- a/build/buildHTML.js
+++ b/build/buildHTML.js
@@ -95,7 +95,7 @@ export default async function buildHTML() {
   await outputFile(joinPath(distDir, `index.html`), appHTML);
 
   // build the HTML for individual pages
-  const pages = await recurse(pagesDir);
+  const pages = await recurse(pagesDir, { depth: 1 });
 
   for await (const entry of pages) {
     await buildPageHTML(entry);

--- a/build/buildJS.js
+++ b/build/buildJS.js
@@ -4,5 +4,3 @@ import config    from './esbuild.config.js';
 export default async function buildJS() {
   await build(config);
 }
-
-buildJS();

--- a/build/esbuild.config.js
+++ b/build/esbuild.config.js
@@ -1,19 +1,30 @@
 import { fileURLToPath } from 'url';
+import recurse           from 'readdirp';
 
 import {
   dirname as getDirname,
+  extname as getExt,
   join    as joinPath,
 } from 'path';
 
-const currentDir = getDirname(fileURLToPath(import.meta.url));
-const env        = process.env.GITHUB_EVENT_NAME === `release` ? `production` : `development`;
+const currentDir  = getDirname(fileURLToPath(import.meta.url));
+const env         = process.env.GITHUB_EVENT_NAME === `release` ? `production` : `development`;
+const srcDir      = joinPath(currentDir, `../src`);
+const entryPoints = [joinPath(srcDir, `App/App.js`)];
+const pageScripts = await recurse(joinPath(srcDir, `pages`));
+
+for await (const entry of pageScripts) {
+  const ext = getExt(entry.basename);
+  if (ext !== `.js`) continue;
+  entryPoints.push(entry.fullPath);
+}
 
 export default {
   bundle:      true,
-  entryPoints: [joinPath(currentDir, `../src/App/App.js`)],
+  entryPoints,
   format:      `esm`,
   minify:      env === `production`,
-  outbase:     joinPath(currentDir, `../src`),
+  outbase:     srcDir,
   outdir:      joinPath(currentDir, `../dist`),
   sourcemap:   env === `production` ? true : `inline`,
   target:      [

--- a/build/index.js
+++ b/build/index.js
@@ -1,5 +1,5 @@
-import buildCSS          from './buildCSS.js';
 import buildCache        from './buildCache.js';
+import buildCSS          from './buildCSS.js';
 import buildHTML         from './buildHTML.js';
 import buildJS           from './buildJS.js';
 import buildSVG          from './buildSVG.js';

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -2,23 +2,37 @@
  * @namespace App
  */
 
+import View from '../core/View.js';
+
+// Make View module available globally for pages and components.
+window.View = View;
+
 /**
  * The top-level view for the app
  * @memberof App
+ * @extends View
  * @instance
  */
-export default class App {
+export default class App extends View {
 
   // PROPERTIES
 
   /**
    * References to DOM elements used by the App View
    * @type {Object}
-   * @prop {HTMLElement} info   - A reference to the ARIA live region (`<p id=info hidden aria-live=polite>`) where content is announced to screen readers
+   * @prop {HTMLElement} info      - The ARIA live region (`<p id=info hidden aria-live=polite>`) where content is announced to screen readers
+   * @prop {HTMLElement} templates - A `<div>` containing any `<template>` tags that have been populated.
    */
   nodes = {
-    info: document.getElementById(`info`),
+    info:      document.getElementById(`info`),
+    templates: document.getElementById(`templates`),
   }
+
+  /**
+   * A Map of page views, loaded dynamically when the page is requested.
+   * @type {Map}
+   */
+  pages = new Map;
 
   // METHODS
 
@@ -28,6 +42,47 @@ export default class App {
    */
   announce(text) {
     this.nodes.info.textContent = text;
+  }
+
+  /**
+   * Asychronously loads the HTML + CSS for a page and inserts it as a `<template>` tag in the app shell for repeated use. Also loads the View for the requested page, and stores it in the `pages` map for repeated use.
+   * @param  {String}  page The page to load
+   * @return {Promise}
+   */
+  async loadPage(page) {
+
+    // load page view
+    const { default: PageView } = await import(`../pages/${ page }/${ page }.js`);
+    this.pages.set(page, PageView);
+
+    // load HTML template
+    const response = await fetch(`../pages/${ page }/${ page }.html`);
+    const html     = await response.text();
+    const template = document.createElement(`template`);
+
+    template.setAttribute(`id`, `${ page.toLowerCase() }-page-template`);
+    template.innerHTML = html;
+    this.nodes.templates.appendChild(template);
+
+  }
+
+  /**
+   * Renders a page.
+   * @param  {String} page The page to render.
+   * @return {Promise}
+   */
+  async renderPage(page) {
+
+    let PageView = this.pages.get(page);
+    if (!PageView) await this.loadPage(page);
+    PageView = this.pages.get(page);
+
+    const pageView = new PageView;
+    const newPage  = pageView.render();
+    const oldPage  = document.body.querySelector(`.main`);
+
+    oldPage.replaceWith(newPage);
+
   }
 
 }

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -18,7 +18,7 @@ export default class App extends View {
   // PROPERTIES
 
   /**
-   * References to DOM elements used by the App View
+   * A table of references to DOM elements used by the App View
    * @type {Object}
    * @prop {HTMLElement} info      - The ARIA live region (`<p id=info hidden aria-live=polite>`) where content is announced to screen readers
    * @prop {HTMLElement} templates - A `<div>` containing any `<template>` tags that have been populated.

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -1,3 +1,3 @@
 # Core
 
-This folder contains modules that are used by higher-level components of the Lotus app. These modules do not have any accompanying HTML templates.
+This folder contains modules that are used by higher-level components of the Lotus app. These modules do not have any accompanying HTML templates. They can be thought of as part of the development environment available to all components. They are made available globally by the App when it is initialized.

--- a/src/core/View.js
+++ b/src/core/View.js
@@ -16,6 +16,12 @@ export default class View {
   el;
 
   /**
+   * A reference to the `<template>` tag for this View.
+   * @type {HTMLTemplateElement}
+   */
+  template;
+
+  /**
    * Use an `addListeners()` method to attach listeners to an element. The `addListeners()` method of the base View class is a no-op. View subclasses should overwrite this method.
    */
   addListeners() { /* no-op */ }

--- a/src/index.html
+++ b/src/index.html
@@ -58,32 +58,29 @@
     {{!-- the main content of the page (should always be a `<main id={page}>` element --}}
     {{> Home}}
 
+    {{!-- an AIRA live region for announcing messages to screen readers --}}
+    <p id=info hidden aria-live=polite></p>
+
+    {{!-- SVG sprites, which can be reused across the app with the <use> tag --}}
+    {{> sprites}}
+
+    {{!-- template tags for pages and components will get populated here --}}
+    <div id=templates hidden></div>
+
+    {{!-- app-level scripts go here --}}
+    <script type=module>
+
+      // initialize the app
+      import App from './App/App.js';
+      window.app = new App;
+
+      // register the offline service worker
+      if ('serviceWorker' in navigator && navigator.onLine) {
+        navigator.serviceWorker.register('offline-worker.js');
+      }
+
+    </script>
+
   </body>
-
-  {{!-- an AIRA live region for announcing messages to screen readers --}}
-  <p id=info hidden aria-live=polite></p>
-
-  {{!-- SVG sprites, which can be reused across the app with the <use> tag --}}
-  {{> sprites}}
-
-  {{!-- app-level scripts go here --}}
-  <script>
-
-    // register the offline service worker
-    if ('serviceWorker' in navigator && navigator.onLine) {
-      navigator.serviceWorker.register('offline-worker.js');
-    }
-
-  </script>
-
-  {{!-- initialize the App --}}
-  {{!-- NB: This script is inlined so that the browser doesn't have to make a separate request for it --}}
-  <script type=module>
-
-    import App from './App/App.js';
-
-    window.app = new App;
-
-  </script>
 
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -52,12 +52,11 @@
     {{!-- skip link --}}
     <a href=#main class=skip-link>Skip to main content</a>
 
-    {{!-- The main banner for the app, containing the app logo and high-level app controls --}}
+    {{!-- the main banner for the app, containing the app logo and high-level app controls --}}
     {{> Banner}}
 
-    <main id=main class=main>
-      {{> Home}}
-    </main>
+    {{!-- the main content of the page (should always be a `<main id={page}>` element --}}
+    {{> Home}}
 
   </body>
 
@@ -67,10 +66,10 @@
   {{!-- SVG sprites, which can be reused across the app with the <use> tag --}}
   {{> sprites}}
 
-  {{!-- App-level scripts go here --}}
+  {{!-- app-level scripts go here --}}
   <script>
 
-    // Register the offline service worker
+    // register the offline service worker
     if ('serviceWorker' in navigator && navigator.onLine) {
       navigator.serviceWorker.register('offline-worker.js');
     }

--- a/src/offline-worker.js
+++ b/src/offline-worker.js
@@ -1,13 +1,13 @@
 /* eslint-env serviceworker */
 
-const cacheName = 'dlx';
+const cacheName = `dlx`;
 
 // NOTE: Filenames in the asset list need to start with an initial slash
 // in order to be matched correctly curing cleanupCache().
 let assets = [];
 
 async function cacheAssets() {
-  const response = await fetch('cache.json');
+  const response = await fetch(`cache.json`);
   assets         = await response.json();
   const cache    = await caches.open(cacheName);
   await cache.addAll(assets);
@@ -30,14 +30,14 @@ async function cleanupCache() {
 async function resolveResponse(ev) {
 
   const { request } = ev;
-  if (request.method !== 'GET') return fetch(request);
+  if (request.method !== `GET`) return fetch(request);
 
   const cache           = await caches.open(cacheName);
   const cacheResponse   = await cache.match(request);
 
   const networkResponse = fetch(request).then(response => {
 
-    if (!response || response.status !== 200 || response.type !== 'basic') {
+    if (!response || response.status !== 200 || response.type !== `basic`) {
       return response;
     }
 
@@ -53,6 +53,6 @@ async function resolveResponse(ev) {
 
 }
 
-self.addEventListener('activate', ev => ev.waitUntil(cleanupCache()));
-self.addEventListener('fetch', ev => ev.respondWith(resolveResponse(ev)));
-self.addEventListener('install', ev => ev.waitUntil(cacheAssets()));
+self.addEventListener(`activate`, ev => ev.waitUntil(cleanupCache()));
+self.addEventListener(`fetch`, ev => ev.respondWith(resolveResponse(ev)));
+self.addEventListener(`install`, ev => ev.waitUntil(cacheAssets()));

--- a/src/pages/.eslintrc.yml
+++ b/src/pages/.eslintrc.yml
@@ -1,0 +1,2 @@
+globals:
+  View: true

--- a/src/pages/Home/Home.html
+++ b/src/pages/Home/Home.html
@@ -1,7 +1,11 @@
-<h1>Lotus</h1>
+<main id=home>
 
-<h2>Coming soon!</h2>
+  <h1>Lotus</h1>
 
-<p>The Lotus app is a tool for linguists to manage their linguistic data, including lexicons, texts, and cognate sets. Keep checking back for updates!</p>
-<p><a href=https://digitallinguistics.io>Learn more about the Digital Linguistics project here!</a></p>
-<p><a href=https://twitter.com/digitalling>Follow Digital Linguistics on Twitter!</a></p>
+  <h2>Coming soon!</h2>
+
+  <p>The Lotus app is a tool for linguists to manage their linguistic data, including lexicons, texts, and cognate sets. Keep checking back for updates!</p>
+  <p><a href=https://digitallinguistics.io>Learn more about the Digital Linguistics project here!</a></p>
+  <p><a href=https://twitter.com/digitalling>Follow Digital Linguistics on Twitter!</a></p>
+
+</main>

--- a/src/pages/Home/Home.html
+++ b/src/pages/Home/Home.html
@@ -1,4 +1,4 @@
-<main id=home>
+<main id=home-page>
 
   <h1>Lotus</h1>
 

--- a/src/pages/Home/Home.html
+++ b/src/pages/Home/Home.html
@@ -1,4 +1,4 @@
-<main id=home-page>
+<main id=home-page class=main>
 
   <h1>Lotus</h1>
 

--- a/src/pages/Home/Home.js
+++ b/src/pages/Home/Home.js
@@ -1,0 +1,15 @@
+import View from '../../core/View.js';
+
+export default class HomePage extends View {
+
+  /**
+   * Render the Home Page.
+   * @return {HTMLMainElement}
+   */
+  render() {
+    this.template = document.getElementById(`home-page-template`);
+    this.el       = this.template.content.cloneNode(true);
+    return this.el;
+  }
+
+}

--- a/src/pages/Home/Home.js
+++ b/src/pages/Home/Home.js
@@ -1,5 +1,3 @@
-import View from '../../core/View.js';
-
 export default class HomePage extends View {
 
   /**

--- a/src/pages/Languages/Languages.html
+++ b/src/pages/Languages/Languages.html
@@ -1,0 +1,5 @@
+<main id=languages-page>
+
+  <h1>Languages</h1>
+
+</main>

--- a/src/pages/Languages/Languages.html
+++ b/src/pages/Languages/Languages.html
@@ -1,4 +1,4 @@
-<main id=languages-page>
+<main id=languages-page class=main>
 
   <h1>Languages</h1>
 

--- a/src/pages/Languages/Languages.js
+++ b/src/pages/Languages/Languages.js
@@ -1,0 +1,15 @@
+import View from '../../core/View.js';
+
+export default class LanguagesPage extends View {
+
+  /**
+   * Render the Languages Page.
+   * @return {HTMLMainElement}
+   */
+  render() {
+    this.template = document.getElementById(`languages-page-template`);
+    this.el       = this.template.content.cloneNode(true);
+    return this.el;
+  }
+
+}

--- a/src/pages/Languages/Languages.js
+++ b/src/pages/Languages/Languages.js
@@ -1,5 +1,3 @@
-import View from '../../core/View.js';
-
 export default class LanguagesPage extends View {
 
   /**


### PR DESCRIPTION
This is a stacked PR that builds on #114.

* Adds `loadPage()` and `renderPage()` methods to the `App` view.
* Adds documentation about page loading. (The HTML, CSS, and JS for each page are loaded asynchronously when that page is requested. The `app.loadPage()` method loads the assets for the page, and `app.renderPage()` actually does the rendering.)
* Adds a `HomePage` View.
* Adds a `LanguagesPage` View.
* Fixes an issue where the list of files to cache offline wasn't generating properly.
* Updates `buildHTML.js` to compile the HTML for each page into a single file and copy the output to `dist/`.
* Updates `buildJS.js` to compile the JS for each page into a single bundle and copy the output to `dist/`.
* Does _not_ add any build steps for page-level CSS (yet).

Currently the only way to render a page is to call `app.renderPage('{page name}')` in the console.

closes #51
closes #113