### PR TITLE
 Add txn class to names listed in Languages Nav

### DIFF
--- a/src/pages/Languages/LanguagesNav/LanguagesNav.js
+++ b/src/pages/Languages/LanguagesNav/LanguagesNav.js
@@ -44,7 +44,7 @@ export default class LanguagesNav extends View {
 
   // NOTE: Must use assignment here to override `template` property on List class.
   itemTemplate({ cid, name }) {
-    return View.fromHTML(`<li data-id='${ cid }'><a href=#language-editor>${ name.default }</a></li>`);
+    return View.fromHTML(`<li class="txn" data-id='${ cid }'><a href=#language-editor>${ name.default }</a></li>`);
   }
 
 }


### PR DESCRIPTION
**Related Issue:**
#212 
**Description of Changes**
Language names listed on the Languages Nav page now have .txn class applied to them
<!-- In 1-3 sentences, provide an overview of what changes were made and why. -->