### PR TITLE
use aria-label for icon-only buttons

### DIFF
--- a/src/App/Nav/Nav.hbs
+++ b/src/App/Nav/Nav.hbs
@@ -1,8 +1,7 @@
 <nav id=nav class=nav>
 
-  <button aria-expanded=true aria-label="Menu" type=button>
+  <button aria-expanded=true aria-label="Main Menu" type=button>
     <svg><use xlink:href=#menu></use></svg>
-    <!-- <span class=visually-hidden>Menu</span> -->
   </button>
 
   <!-- NOTE: The `alt` attribute is blank on these images because they are decorative. -->

--- a/src/App/Nav/Nav.hbs
+++ b/src/App/Nav/Nav.hbs
@@ -1,8 +1,8 @@
 <nav id=nav class=nav>
 
-  <button aria-expanded=true type=button>
+  <button aria-expanded=true aria-label="Menu" type=button>
     <svg><use xlink:href=#menu></use></svg>
-    <span class=visually-hidden>Menu</span>
+    <!-- <span class=visually-hidden>Menu</span> -->
   </button>
 
   <!-- NOTE: The `alt` attribute is blank on these images because they are decorative. -->


### PR DESCRIPTION
**Related Issue:**
closes #208 
**Description of Changes**
Changed icon-only buttons to `aria-label` field instead of a hidden span field. Only found one instance of the hidden span field: the menu button in the main nav.
<!-- In 1-3 sentences, provide an overview of what changes were made and why. -->