### PR TITLE
add help text for Additional Names

### DIFF
--- a/src/pages/Languages/AdditionalName/AdditionalName.hbs
+++ b/src/pages/Languages/AdditionalName/AdditionalName.hbs
@@ -9,29 +9,33 @@
   <fieldset class='js-editor' hidden>
     <div class=text-field>
       <label data-bind=for:nameID>Name</label>
-      <input
-        autocomplete=off
-        class='js-name-input line-input txn'
-        data-bind=id:nameID;value:name
-        inputmode=text
-        placeholder='e.g. espagnol'
-        spellcheck=false
-        type=text
-      >
-      <p class=help-text>An additional name for this language.</p>
+      <div>
+        <input
+          autocomplete=off
+          class='js-name-input line-input txn'
+          data-bind=id:nameID;value:name
+          inputmode=text
+          placeholder='e.g. espagnol'
+          spellcheck=false
+          type=text
+        >
+        <p class=help-text>An additional name for this language.</p>
+      </div>
     </div>
     <div class=text-field>
       <label data-bind=for:langID>Language</label>
-      <input
-        autocomplete=off
-        class='js-lang-input line-input'
-        data-bind=id:langID;value:language
-        inputmode=text
-        placeholder='e.g. French'
-        spellcheck=false
-        type=text
-      >
-      <p class=help-text>The language of this additional name.</p>
+      <div>
+        <input
+          autocomplete=off
+          class='js-lang-input line-input'
+          data-bind=id:langID;value:language
+          inputmode=text
+          placeholder='e.g. French'
+          spellcheck=false
+          type=text
+        >
+        <p class=help-text>The language of this additional name.</p>
+      </div>
     </div>
     <div class=buttons>
       <button class='button js-cancel-button' type=button>Cancel</button>

--- a/src/pages/Languages/AdditionalName/AdditionalName.hbs
+++ b/src/pages/Languages/AdditionalName/AdditionalName.hbs
@@ -18,6 +18,7 @@
         spellcheck=false
         type=text
       >
+      <p class=help-text>An additional name for this language.</p>
     </div>
     <div class=text-field>
       <label data-bind=for:langID>Language</label>
@@ -30,6 +31,7 @@
         spellcheck=false
         type=text
       >
+      <p class=help-text>The language of this additional name.</p>
     </div>
     <div class=buttons>
       <button class='button js-cancel-button' type=button>Cancel</button>


### PR DESCRIPTION
**Related Issue:**
closes #258 
**Description of Changes**
Add `help-text` styled help text to the additional names editor.
<!-- In 1-3 sentences, provide an overview of what changes were made and why. -->