### PR TITLE
Notes List component tests

### DIFF
--- a/src/components/NotesList/NotesList.component.js
+++ b/src/components/NotesList/NotesList.component.js
@@ -9,19 +9,64 @@ describe(`Notes List`, function() {
     
     cy.visit(`http://localhost:6006/iframe.html?id=components-notes-list--empty`);
     
+    cy.contains(`h3`, `Notes (0)`);
+    
     cy.get(`.js-add-note-button`)
     .click();
+    
+    cy.contains(`h3`, `Notes (1)`);
     
     cy.get(`.notes`)
     .children()
     .should(`have.lengthOf`, 1);
-
+    
+    cy.focused()
+    .should(`have.class`, `js-text-input`);
+    
     cy.get(`.note .js-delete-button`)
     .click();
+    
+    cy.contains(`h3`, `Notes (0)`);
 
     cy.get(`.notes`)
     .children()
     .should(`have.lengthOf`, 0);
+
+  });
+
+  it(`has expanded / collapsed states`, function() {
+
+    cy.visit(`http://localhost:6006/iframe.html?id=components-notes-list--collapsed`);
+
+    cy.contains(`.notes .note-item:first-child .js-text-preview`, `Note A`)
+    .should(`not.be.visible`);
+
+    // click a note
+
+    cy.get(`.notes .note-item:first-child .js-note-button`)
+    .click();
+
+    cy.contains(`.notes .note-item:first-child .js-text-preview`, `Note A`)
+    .should(`be.visible`);
+
+    // add a note
+
+    cy.get(`.js-add-note-button`)
+    .click();
+
+    cy.focused()
+    .should(`have.class`, `js-text-input`);
+
+    cy.contains(`.notes .note-item:nth-child(2) .js-text-preview`, `Note A`)
+    .should(`not.be.visible`);
+
+    // expand
+
+    cy.get(`h3`)
+    .click();
+
+    cy.contains(`.notes .note-item:nth-child(2) .js-text-preview`, `Note A`)
+    .should(`be.visible`);
 
   });
 


### PR DESCRIPTION
**Related Issue:**

closes #221

**Description of Changes**

Adds component tests for the Notes List. Unfortunately I accidentally merged all the functional code into `main` already, and it's strung out over various commits, so it's not easily reviewable. However, you can look at the diff [here](https://github.com/digitallinguistics/app/compare/a6c2b0e...f415040). If you want to comment on them though, you'll need to copy the link to that line of code in `main` and paste it here. (Sorry!)