### PR TITLE
TranscriptionGroup focus style

### DIFF
--- a/src/components/NavList/NavList.js
+++ b/src/components/NavList/NavList.js
@@ -5,8 +5,8 @@ import List from '../List/List.js';
  */
 export default class NavList extends List {
 
-  constructor(options) {
-    super(options);
+  constructor(data, options) {
+    super(data, options);
     this.name = options.name ?? `item`;
   }
 

--- a/src/components/TranscriptionGroup/TranscriptionGroup.less
+++ b/src/components/TranscriptionGroup/TranscriptionGroup.less
@@ -3,6 +3,8 @@
 
 .txn-group {
 
+  --display-color: var(--blue);
+
   align-items:           baseline;
   column-gap:            var(--space-xs);
   display:               grid;
@@ -14,6 +16,29 @@
   input {
     grid-column: input;
     min-width:   10em;
+
+    &:focus {
+
+      border-block-end-color: currentColor;
+      color:                  var(--display-color);
+      outline-color:          var(--display-color);
+
+      &::placeholder {
+        color:      currentColor;
+        font-style: italic;
+      }
+
+      &:invalid {
+
+        --display-color: var(--red);
+
+        + .help-text {
+          color: var(--red);
+        }
+
+      }
+
+    }
   }
 
   label {

--- a/src/components/TranscriptionGroup/TranscriptionGroup.less
+++ b/src/components/TranscriptionGroup/TranscriptionGroup.less
@@ -28,10 +28,6 @@
         font-style: italic;
       }
 
-      + .help-text {
-        color: var(--display-color);
-      }
-
       &:invalid {
 
         --display-color: var(--red);

--- a/src/components/TranscriptionGroup/TranscriptionGroup.less
+++ b/src/components/TranscriptionGroup/TranscriptionGroup.less
@@ -28,6 +28,10 @@
         font-style: italic;
       }
 
+      + .help-text {
+        color: var(--display-color);
+      }
+
       &:invalid {
 
         --display-color: var(--red);


### PR DESCRIPTION
**Related Issue:**
closes #177 
**Description of Changes**
TranscriptionGroups now have the same styling as InputGroups when they are focused (blue border, blue placeholder text, etc.). Help-text does not change color based on a decision made in #177. The help-text code can be removed if @dwhieb confirms a `<p class=help-text>` can never exist within a TranscriptionGroup fieldset.
<!-- In 1-3 sentences, provide an overview of what changes were made and why. -->