### PR TITLE
Correct the label name to "Abbreviation"

### DIFF
--- a/src/components/Abbreviation/Abbreviation.stories.js
+++ b/src/components/Abbreviation/Abbreviation.stories.js
@@ -4,5 +4,5 @@ export default {
   title: `Components/Abbreviation`,
 };
 
-export const Required = () => `<p>The acronym <abbr class="abbr" title="Digital Linguistics">DLx</abbr> stands for "Digital Linguistics".</p>
+export const Abbreviation = () => `<p>The acronym <abbr class="abbr" title="Digital Linguistics">DLx</abbr> stands for "Digital Linguistics".</p>
 `;


### PR DESCRIPTION
**Related Issue:**
#247
**Description of Changes**
Renamed the label name in Abbreviation story.