### PR TITLE
Language Name: add `"for"` and `"id"` attributes

### DIFF
--- a/src/components/MultiLangStringEditor/MultiLangStringEditor.js
+++ b/src/components/MultiLangStringEditor/MultiLangStringEditor.js
@@ -40,14 +40,15 @@ export default class MultiLangStringEditor extends View {
 
     for (const [lang, text] of strings) {
 
-      const label = View.fromHTML(`<label class=label>${ lang }</label>`);
+      const id    = `${ this.fieldName }-${ lang }`;
+      const label = View.fromHTML(`<label class=label for='${ id }'>${ lang }</label>`);
 
       const input = View.fromHTML(`<input
         autocomplete=off
         class='line-input txn'
         inputmode=text
         lang='${ lang }'
-        name='${ this.fieldName }-${ lang }'
+        name='${ id }'
         placeholder='${ this.placeholder }'
         spellcheck=false
         type=text

--- a/src/components/MultiLangStringEditor/MultiLangStringEditor.js
+++ b/src/components/MultiLangStringEditor/MultiLangStringEditor.js
@@ -46,6 +46,7 @@ export default class MultiLangStringEditor extends View {
       const input = View.fromHTML(`<input
         autocomplete=off
         class='line-input txn'
+        id='${ id }'
         inputmode=text
         lang='${ lang }'
         name='${ id }'


### PR DESCRIPTION
**Related Issue:** N/A

**Description of Changes**

The Language Name field in the Language Editor was missing the `"for"` attribute on the `<label>` and the `"id"` attribute on the `<input>`. This PR adds them.