### PR TITLE
remove `hydrate()` method from View

### DIFF
--- a/src/components/Note/Note.hbs
+++ b/src/components/Note/Note.hbs
@@ -32,12 +32,11 @@
     <fieldset class='note__editor js-note__editor'>
 
       <div class=note__input-group>
-        <label class=legend data-bind=for:textID>Note Text</label>
+        <label class='legend js-note__text-legend'>Note Text</label>
         <p class=help-text note__help-text>The text of the note.</p>
         <textarea
           autocomplete=off
           class='box-input js-note__text-input note__text-input'
-          data-bind=id:textID
           inputmode=text
           placeholder='Type your note here.'
           rows=4
@@ -45,12 +44,11 @@
       </div>
       
       <div class=note__input-group>
-        <label class=legend data-bind=for:sourceID>Source</label>
+        <label class='legend js-note__src-legend'>Source</label>
         <p class=help-text note__help-text>The source of this note (person, bibliographic item, etc.).</p>
         <input
           autocomplete=off
           class='box-input js-note__src-input note__src-input'
-          data-bind=id:sourceID
           inputmode=text
           placeholder='e.g. DWH'
           spellcheck=false

--- a/src/components/Note/Note.js
+++ b/src/components/Note/Note.js
@@ -36,8 +36,12 @@ export default class NoteView extends View {
     this.textInput = this.el.querySelector(`.js-note__text-input`);
     this.srcInput  = this.el.querySelector(`.js-note__src-input`);
 
+    this.textInput.setAttribute(`id`, this.textID);
+    this.srcInput.setAttribute(`id`, this.sourceID);
+    this.el.querySelector(`.js-note__text-legend`).setAttribute(`for`, this.textID);
+    this.el.querySelector(`.js-note__src-legend`).setAttribute(`for`, this.sourceID);
+
     this.updatePreview();
-    this.hydrate();
     this.addEventListeners();
 
     return this.el;

--- a/src/core/View.js
+++ b/src/core/View.js
@@ -41,19 +41,6 @@ export default class View {
   }
 
   /**
-   * Set the attributes for any elements within the DOM tree for this view based on the value of the `data-bind` attribute. The value of the `data-bind` attribute should be `{attr}:{prop}`, where `attr` is the name of the attribute to set on the element, and `prop` is the property on the view that contains the value to use for that attribute. For example, if the view has a property `inputName: 'cid'`, using `data-bind=name:inputName` will set the `name` attribute of the element to `'cid'`. Multiple `data-bind` directives may be separated by semicolons.
-   */
-  hydrate() {
-    for (const el of this.el.querySelectorAll(`[data-bind]`)) {
-      const attributes = el.dataset.bind.split(/\s*;\s*/u).filter(Boolean);
-      for (const attribute of attributes) {
-        const [attr, prop] = attribute.split(/\s*:\s*/u);
-        if (typeof this[prop] !== `undefined`) el.setAttribute(attr, this[prop]);
-      }
-    }
-  }
-
-  /**
    * Compile the DOM tree for this view, set the value of `this.el` to the element for this view, and return that element. Views should not insert themselves into the DOM; this is the responsibility of their parent view/controller. Views should however attach event listeners to their elements by calling {@link View#addEventListeners}. This method should be overwritten by view instances.
    * @abstract
    */


### PR DESCRIPTION
**Related Issue:** N/A

**Description of Changes**

Removes the `hydrate()` method from the View, and any views that use it, in preparation for changing how templates are loaded and rendered (see #214).