### PR TITLE
remove details marker from HelpMenu (Safari)

### DIFF
--- a/src/App/HelpMenu/HelpMenu.less
+++ b/src/App/HelpMenu/HelpMenu.less
@@ -74,6 +74,10 @@
     cursor        : pointer;
     display       : flex;
     flex-direction: row;
+
+    &::-webkit-details-marker {
+      display: none;
+    }
   }
 
   @media (max-width: @breakpoint) {


### PR DESCRIPTION
**Related Issue:**
closes #325 
**Description of Changes**
Adjusted HelpMenu styling to remove the details marker.
<!-- In 1-3 sentences, provide an overview of what changes were made and why. -->