### PR TITLE
add `fit-content` vendor prefix (Firefox)

### DIFF
--- a/src/App/Nav/Nav.less
+++ b/src/App/Nav/Nav.less
@@ -1,6 +1,11 @@
 @import (reference) 'utilities';
 @import (reference) 'variables';
 
+span {
+  padding:     var(--text-padding);
+  white-space: nowrap;
+}
+
 #nav {
 
   background-color: white;
@@ -36,10 +41,6 @@
 
   }
 
-  span {
-    padding:     var(--text-padding);
-    white-space: nowrap;
-  }
 
   svg {
     --icon-size: 1.5em;
@@ -77,9 +78,11 @@
         .visually-hidden;
       }
       li {
+        width: -moz-fit-content; /* stylelint-disable-line */
         width: fit-content;
       }
       a {
+        width: -moz-fit-content; /* stylelint-disable-line */
         width: fit-content;
       }
     }


### PR DESCRIPTION
**Related Issue:**
closes #323 
**Description of Changes**
Add `-moz-fit-content` declarations before `fit-content` declarations.
<!-- In 1-3 sentences, provide an overview of what changes were made and why. -->