### PR TITLE
Apply mono font styling to codes

### DIFF
--- a/src/App/App.less
+++ b/src/App/App.less
@@ -5,6 +5,7 @@
 @import 'Banner/Banner.less';
 @import 'BlockHeader/BlockHeader.less';
 @import 'Button/Button.less';
+@import 'Code/Code.less';
 @import 'Footer/Footer.less';
 @import 'HelpMenu/HelpMenu.less';
 @import 'Nav/Nav.less';

--- a/src/components/Code/Code.less
+++ b/src/components/Code/Code.less
@@ -1,0 +1,3 @@
+.code {
+  font-family: var(--font-mono);
+}

--- a/src/components/Code/Code.stories.js
+++ b/src/components/Code/Code.stories.js
@@ -1,0 +1,7 @@
+import '../../../dist/components/Code/Code.css';
+
+export default {
+  title: `Components/Code`,
+};
+
+export const Code = () => `<p>This is some text with a <span class=code>code</span> in it.</p>`;

--- a/src/pages/Languages/AnalysisLanguage/AnalysisLanguage.js
+++ b/src/pages/Languages/AnalysisLanguage/AnalysisLanguage.js
@@ -125,8 +125,8 @@ export default class AnalysisLanguage extends View {
 
   updatePreview(lang, abbr, tag) {
     this.el.querySelector(`.js-analysis-language__preview`)
-    .innerHTML = `<span>${ lang }</span> <span class=analysis-language__mono>${ abbr }</span>
-      <span class=analysis-language__mono>${ tag }</span>`;
+    .innerHTML = `<span>${ lang }</span> <span class='analysis-language code'>${ abbr }</span>
+      <span class='analysis-language code'>${ tag }</span>`;
   }
 
 }

--- a/src/pages/Languages/AnalysisLanguage/AnalysisLanguage.less
+++ b/src/pages/Languages/AnalysisLanguage/AnalysisLanguage.less
@@ -29,10 +29,6 @@
     }
   }
 
-  &__abbr-input {
-    font: var(--font-mono);
-  }
-
   &__button {
     margin: var(--space-xxxs);
   }
@@ -82,10 +78,6 @@
     inline-size: 15rem;
   }
 
-  &__mono {
-    font: var(--font-mono);
-  }
-
   &__preview {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
@@ -95,10 +87,6 @@
     span {
       overflow-wrap: anywhere;
     }
-  }
-
-  &__tag-input {
-    font: var(--font-mono);
   }
 
 }

--- a/src/pages/Languages/LanguageEditor/LanguageEditor.hbs
+++ b/src/pages/Languages/LanguageEditor/LanguageEditor.hbs
@@ -19,7 +19,7 @@
         <input
           autocapitalize=off
           autocomplete=off
-          class=line-input
+          class='line-input code'
           id=language-editor__abbreviation-input
           inputmode=text
           name=abbreviation
@@ -38,7 +38,7 @@
         <input
           autocapitalize=off
           autocomplete=off
-          class=line-input
+          class='line-input code'
           id=language-editor__iso-input
           inputmode=text
           name=iso
@@ -56,7 +56,7 @@
         <input
           autocapitalize=off
           autocomplete=off
-          class=line-input
+          class='line-input code'
           id=language-editor__glottocode-input
           inputmode=text
           name=glottocode

--- a/src/pages/Languages/Orthography/Orthography.js
+++ b/src/pages/Languages/Orthography/Orthography.js
@@ -137,7 +137,7 @@ export default class Orthography extends View {
     this.el.querySelector(`.js-orthography__preview`)
     .innerHTML = `<span><span class=label> Name </span><span class=txn>${ name }
     </span></span><span><span class=label>Abbreviation</span>
-    <span class=orthography__mono>${ abbreviation }</span></span>`;
+    <span class='orthography code'>${ abbreviation }</span></span>`;
   }
 
 }

--- a/src/pages/Languages/Orthography/Orthography.less
+++ b/src/pages/Languages/Orthography/Orthography.less
@@ -26,9 +26,7 @@
       display: none;
     }
   }
-  &__abbr-input {
-    font: var(--font-mono);
-  }
+
   &__button {
     margin: var(--space-xxxs);
   }
@@ -89,9 +87,7 @@
   &__line-input {
     inline-size: 15rem;
   }
-  &__mono {
-    font: var(--font-mono);
-  }
+
   &__preview {
     hyphens: auto;
     padding: var(--text-padding);


### PR DESCRIPTION
**Related Issue:**
closes #387 
**Description of Changes**
Created a global component with styling for codes, similar to the `Transcription` component, and applied it to the code fields in the LanguageEditor.