### PR TITLE
add/delete analysis languages

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Digital Linguistics
+Copyright (c) 2022 Digital Linguistics
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository contains the source code for the Digital Linguistics (DLx) [Lotu
 
 If you use the Lotus app in your work, please consider citing it similar to the following model:
 
-> Hieber, Daniel W. 2021. Lotus (@digitallinguistics/app). https://github.com/digitallinguistics/app
+> Hieber, Daniel W. 2022. Lotus (@digitallinguistics/app). https://github.com/digitallinguistics/app
 
 <!-- LINKS -->
 [app]:          https://app.digitallinguistics.io

--- a/src/services/Database.js
+++ b/src/services/Database.js
@@ -48,7 +48,7 @@ export default class Database {
     },
     Lexeme: {
       Model:     Lexeme,
-      storeName: `Lexemes`,
+      storeName: `lexemes`,
     },
     Text:     {
       Model:     Text,
@@ -79,6 +79,89 @@ export default class Database {
   // METHODS
 
   /**
+   * Add a new analysis language to all of the database items related to the specified language. All properties on the analysis language are required, even if they are empty strings.
+   * @param {String} languageCID                   The CID of the language to add the new analysis language to.
+   * @param {Object} analysisLanguage              The analysis language to add to the language.
+   * @param {String} analysisLanguage.abbreviation The abbreviation for this analysis language.
+   * @param {String} analysisLanguage.language     The name of this analysis language.
+   * @param {String} analysisLanguage.tag          The IETF language tag for this analysis language.
+   */
+  addAnalysisLanguage(languageCID, analysisLanguage) {
+    return new Promise(async (resolve, reject) => { // eslint-disable-line no-async-promise-executor
+
+      const txn = this.idb.transaction([`languages`, `lexemes`], `readwrite`);
+
+      txn.onabort    = () => reject(txn.error);
+      txn.oncomplete = () => resolve();
+      txn.onerror    = () => reject(txn.error);
+
+      // update Language data
+      await new Promise(resolve => {
+
+        const languageStore = txn.objectStore(`languages`);
+        const req           = languageStore.get(languageCID);
+
+        req.onsuccess = () => {
+
+          const language = new Language(req.result);
+          const { tag }  = analysisLanguage;
+
+          language.analysisLanguages.push(analysisLanguage);
+          language.name.set(tag, ``);
+
+          for (const orthography of language.orthographies) {
+            orthography.name.set(tag, ``);
+          }
+
+          languageStore.put(language);
+          resolve();
+
+        };
+
+      });
+
+      // update Lexemes for this Language
+      const lexemeStore = txn.objectStore(`lexemes`);
+      const index       = lexemeStore.index(`language`);
+      const keyRange    = IDBKeyRange.only(languageCID);
+      let   progress    = 0;
+
+      const numLexemes = await new Promise(resolve => {
+        const req = index.count(keyRange);
+        req.onsuccess = () => resolve(req.result);
+      });
+
+      await new Promise(resolve => {
+
+        const req = index.openCursor(keyRange);
+
+        req.onsuccess = ev => {
+
+          const cursor = ev.target.result;
+          if (!cursor) return resolve();
+
+          const lexeme = cursor.value;
+          // TODO: Update Lexeme data as appropriate here.
+          cursor.update(lexeme); // this finishes in a separate thread
+          progress++;
+
+          if (this.onupdate) {
+            this.onupdate({
+              count: progress,
+              total: numLexemes,
+            });
+          }
+
+          cursor.continue();
+
+        };
+
+      });
+
+    });
+  }
+
+  /**
    * Configure the Lotus database by adding tables and indexes. Can only be run during an IDBOpenDBRequest.
    * @private
    */
@@ -104,8 +187,12 @@ export default class Database {
     }
 
     if (!this.idb.objectStoreNames.contains(`lexemes`)) {
+
       const store = this.idb.createObjectStore(`lexemes`, { keyPath: `cid` });
+
       store.createIndex(`key`, `key`, { unique: false });
+      store.createIndex(`language`, `language`, { unique: false });
+
     }
 
   }
@@ -141,7 +228,7 @@ export default class Database {
 
   /**
    * Export all the data in the database and return an Array of JavaScript Objects.
-   * @fires   Database#onexportupdate
+   * @fires   Database#onupdate
    * @returns {Promise<Array>}
    */
   exportData() {
@@ -187,8 +274,8 @@ export default class Database {
           data.push(...result);
           exportProgress += ev.target.result.length;
 
-          if (this.onexportupdate) {
-            this.onexportupdate({
+          if (this.onupdate) {
+            this.onupdate({
               count: exportProgress,
               total: numItems,
             });
@@ -294,12 +381,11 @@ export default class Database {
 
 }
 
-
 /**
- * onexportupdate event. This event is fired during database export each time an item is retrieved from the database.
+ * onupdate event. This event is fired during long-running database processes each time an item is added/retrieved/modified/deleted.
  *
- * @event Services.Database#onexportupdate
+ * @event Services.Database#onupdate
  * @type {Object}
- * @property {Integer} count - The current total number of items that have been exported so far.
- * @property {Integer} total - The total number of items to export.
+ * @property {Integer} count - The current total number of items that have been updated so far.
+ * @property {Integer} total - The total number of items to update.
  */

--- a/src/services/Database.js
+++ b/src/services/Database.js
@@ -79,20 +79,23 @@ export default class Database {
   // METHODS
 
   /**
-   * Add a new analysis language to all of the database items related to the specified language. All properties on the analysis language are required, even if they are empty strings.
-   * @param {String} languageCID                   The CID of the language to add the new analysis language to.
-   * @param {Object} analysisLanguage              The analysis language to add to the language.
-   * @param {String} analysisLanguage.abbreviation The abbreviation for this analysis language.
-   * @param {String} analysisLanguage.language     The name of this analysis language.
-   * @param {String} analysisLanguage.tag          The IETF language tag for this analysis language.
+   * Add a new analysis language to the specified Language, and update all of the database items related to the specified language. All properties on the analysis language are required, even if they are empty strings.
+   * @param  {String} languageCID                   The CID of the language to add the new analysis language to.
+   * @param  {Object} analysisLanguage              The analysis language to add to the language.
+   * @param  {String} analysisLanguage.abbreviation The abbreviation for this analysis language.
+   * @param  {String} analysisLanguage.language     The name of this analysis language.
+   * @param  {String} analysisLanguage.tag          The IETF language tag for this analysis language.
+   * @return {Promise<Language>}                    Returns a promise that resolves to the updated Language.
    */
   addAnalysisLanguage(languageCID, analysisLanguage) {
     return new Promise(async (resolve, reject) => { // eslint-disable-line no-async-promise-executor
 
+      // Open a transaction for all the operations in this call.
       const txn = this.idb.transaction([`languages`, `lexemes`], `readwrite`);
+      let language;
 
       txn.onabort    = () => reject(txn.error);
-      txn.oncomplete = () => resolve();
+      txn.oncomplete = () => resolve(language);
       txn.onerror    = () => reject(txn.error);
 
       // update Language data
@@ -103,8 +106,8 @@ export default class Database {
 
         req.onsuccess = () => {
 
-          const language = new Language(req.result);
-          const { tag }  = analysisLanguage;
+          const { tag } = analysisLanguage;
+          language      = new Language(req.result);
 
           language.analysisLanguages.push(analysisLanguage);
           language.name.set(tag, ``);
@@ -204,6 +207,87 @@ export default class Database {
   #createCollections() {
     Object.entries(this.types).forEach(([, { Model, storeName }]) => {
       this[storeName] = new Collection(storeName, Model, this.idb);
+    });
+  }
+
+  /**
+   *
+   * @param {String} languageCID The CID of the language to delete.
+   * @param {String} tag         The IETF language tag to delete from the language.
+   * @return {Promise<Language>} Returns a Promise that resolves to the updated Language.
+   */
+  deleteAnalysisLanguage(languageCID, tag) {
+    return new Promise(async (resolve, reject) => { // eslint-disable-line no-async-promise-executor
+
+      // Open a transaction for all the operations in this call.
+      const txn = this.idb.transaction([`languages`, `lexemes`], `readwrite`);
+      let language;
+
+      txn.onabort = () => reject(txn.error);
+      txn.oncomplete = () => resolve(language);
+      txn.onerror = () => reject(txn.error);
+
+      // update Language data
+      await new Promise(resolve => {
+
+        const languageStore = txn.objectStore(`languages`);
+        const req           = languageStore.get(languageCID);
+
+        req.onsuccess = () => {
+
+          language = new Language(req.result);
+          language.analysisLanguages = language.analysisLanguages.filter(lang => lang.tag !== tag);
+          language.name.delete(tag);
+
+          for (const orthography of language.orthographies) {
+            orthography.name.delete(tag);
+          }
+
+          languageStore.put(language);
+          resolve();
+
+        };
+
+      });
+
+      // update Lexemes for this Language
+      const lexemeStore = txn.objectStore(`lexemes`);
+      const index       = lexemeStore.index(`language`);
+      const keyRange    = IDBKeyRange.only(languageCID);
+      let   progress    = 0;
+
+      const numLexemes = await new Promise(resolve => {
+        const req = index.count(keyRange);
+        req.onsuccess = () => resolve(req.result);
+      });
+
+      await new Promise(resolve => {
+
+        const req = index.openCursor(keyRange);
+
+        req.onsuccess = ev => {
+
+          const cursor = ev.target.result;
+          if (!cursor) return resolve();
+
+          const lexeme = cursor.value;
+          lexeme.deleted = true;
+          cursor.update(lexeme); // this finishes in a separate thread
+          progress++;
+
+          if (this.onupdate) {
+            this.onupdate({
+              count: progress,
+              total: numLexemes,
+            });
+          }
+
+          cursor.continue();
+
+        };
+
+      });
+
     });
   }
 

--- a/src/services/Settings.js
+++ b/src/services/Settings.js
@@ -14,15 +14,16 @@ class Settings {
   #defaults = {
     navOpen: true,
     page:    `Home`,
-  }
-  
+  };
+
   /**
-   * 
+   *
    * @param {Object}  [initialSettings={}]           The settings to instantiate the app with.
    * @param {Boolean} [initialSettings.navOpen=true] Whether the main nav is open.
    * @param {String}  [initialSettings.page=`Home`]  The last visited page.
    * @returns {Proxy<Object>}
    */
+  /* eslint-disable no-constructor-return */
   constructor(initialSettings = {}) {
 
     const settings = Object.assign(this.#defaults, initialSettings);


### PR DESCRIPTION
**Related Issue:**
closes #344
unblocks #459

**Description of Changes**
Adds `addAnalysisLanguage()` and `deleteAnalysisLanguage()` methods to the database module. Both of these methods update the Language object in the database, and return a Promise that resolves to the updated Language object.