### PR TITLE
postcss-less

### DIFF
--- a/.stylelintrc.yml
+++ b/.stylelintrc.yml
@@ -1,4 +1,5 @@
 # Stylelint 14.1.0
+customSyntax: postcss-less
 rules:
 
   # allow lists / regexp

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "mousetrap": "^1.6.5",
         "ora": "^6.0.0",
         "param-case": "^3.0.4",
+        "postcss-less": "^5.0.0",
         "readdirp": "^3.6.0",
         "semver": "^7.3.5",
         "serve-handler": "^6.1.3",
@@ -24097,6 +24098,15 @@
       "dev": true,
       "dependencies": {
         "postcss": "^7.0.26"
+      }
+    },
+    "node_modules/postcss-less": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-5.0.0.tgz",
+      "integrity": "sha512-djK6NlApALJeBnNx7CzLatq64eMF3BCyzBH+faYPxrvNHHM/YCimJ6XQkgWgtim2G89EzdQG4Ed0lGNCXPfD7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/postcss-loader": {
@@ -50002,6 +50012,12 @@
       "requires": {
         "postcss": "^7.0.26"
       }
+    },
+    "postcss-less": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-5.0.0.tgz",
+      "integrity": "sha512-djK6NlApALJeBnNx7CzLatq64eMF3BCyzBH+faYPxrvNHHM/YCimJ6XQkgWgtim2G89EzdQG4Ed0lGNCXPfD7A==",
+      "dev": true
     },
     "postcss-loader": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "mousetrap": "^1.6.5",
     "ora": "^6.0.0",
     "param-case": "^3.0.4",
+    "postcss-less": "^5.0.0",
     "readdirp": "^3.6.0",
     "semver": "^7.3.5",
     "serve-handler": "^6.1.3",


### PR DESCRIPTION
[Stylelint no longer supports LESS syntax natively](https://stylelint.io/migration-guide/to-14/), necessitating the installation of the postcss-less plugin to handle the LESS syntax.