### PR TITLE
Delete Analysis Language: confirm -> prompt

### DIFF
--- a/src/pages/Languages/LanguageEditor/LanguageEditor.component.js
+++ b/src/pages/Languages/LanguageEditor/LanguageEditor.component.js
@@ -116,15 +116,20 @@ describe(`Language Editor`, function() {
 
   it(`deletes an Analysis Language`, function() {
 
-    cy.get(`[data-id="0"]`).within(() => {
-      cy.get(`.js-analysis-language__delete-button`)
-      .click();
+    cy.window().then(win => {
+
+      cy.stub(win, `prompt`).returns(`YES`);
+
+      cy.get(`[data-id="0"]`).within(() => {
+        cy.get(`.js-analysis-language__delete-button`)
+        .click();
+      });
+
+      cy.get(`.js-language-editor__analysis-langs-list`)
+      .children()
+      .should(`have.lengthOf`, 1);
+      
     });
-
-    cy.get(`.js-language-editor__analysis-langs-list`)
-    .children()
-    .should(`have.lengthOf`, 1);
-
   });
 
   it(`deletes an empty Orthography when editing is canceled`, function() {

--- a/src/pages/Languages/LanguageEditor/LanguageEditor.js
+++ b/src/pages/Languages/LanguageEditor/LanguageEditor.js
@@ -127,7 +127,7 @@ export default class LanguageEditor extends View {
         alert(`There must be at least one analysis language.`);
         return;
       }
-      const confirmDelete = prompt(`Are you sure you want to delete this Analysis Language? This action will permanently delete any entries associated with this Analysis Language and it cannot be undone. Type "YES" to delete.`);
+      const confirmDelete = prompt(`Are you sure you want to delete this Analysis Language? This action will permanently delete any data in this Analysis Language and it cannot be undone. Type "YES" to delete.`);
       if (confirmDelete !== `YES`) return;
       const i = Number(target.closest(`.analysis-language`).dataset.id);
       return this.deleteAnalysisLang(i);

--- a/src/pages/Languages/LanguageEditor/LanguageEditor.js
+++ b/src/pages/Languages/LanguageEditor/LanguageEditor.js
@@ -127,8 +127,8 @@ export default class LanguageEditor extends View {
         alert(`There must be at least one analysis language.`);
         return;
       }
-      const confirmDelete = confirm(`Are you sure you want to delete this Analysis Language? This action cannot be undone. Click 'OK' to confirm deletion.`);
-      if (!confirmDelete) return;
+      const confirmDelete = prompt(`Are you sure you want to delete this Analysis Language? This action will permanently delete any entries associated with this Analysis Language and it cannot be undone. Type "YES" to delete.`);
+      if (confirmDelete !== `YES`) return;
       const i = Number(target.closest(`.analysis-language`).dataset.id);
       return this.deleteAnalysisLang(i);
     }


### PR DESCRIPTION
**Related Issue:**
closes #458 
**Description of Changes**
The user now has to type "YES" to delete an analysis language and its associated data instead of just pressing 'OK'.
<!-- In 1-3 sentences, provide an overview of what changes were made and why. -->