### PR TITLE
link to developer docs in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains the source code for the Digital Linguistics (DLx) [Lotu
 
 * [Try out the Lotus app!][app]
 * [Report a problem or request a feature.][new-issue]
-* [Contribute to the project.](./.github/CONTRIBUTING.md)
+* [Contribute to the project.][dev-docs]
 
 ## Attribution
 
@@ -19,6 +19,7 @@ If you use the Lotus app in your work, please consider citing it similar to the 
 
 <!-- LINKS -->
 [app]:          https://app.digitallinguistics.io
+[dev-docs:      https://developer.digitallinguistics.io/app
 [GitHub]:       https://github.com/digitallinguistics/app
 [issues]:       https://github.com/digitallinguistics/app/issues
 [new-issue]:    https://github.com/digitallinguistics/app/issues/new


### PR DESCRIPTION
(no related issue)

This PR links to the new developer docs page (https://developer.digitallinguistics.io) from the project readme.