### PR TITLE
set up Azure Application Insights

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@babel/core": "^7.16.5",
         "@lhci/cli": "^0.8.1",
+        "@microsoft/applicationinsights-web": "^2.7.2",
         "@storybook/builder-webpack5": "~6.3.12",
         "@storybook/html": "~6.3.12",
         "@storybook/manager-webpack5": "~6.3.12",
@@ -3073,6 +3074,124 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/@microsoft/applicationinsights-analytics-js": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-analytics-js/-/applicationinsights-analytics-js-2.7.2.tgz",
+      "integrity": "sha512-f3I1pj/0e2BtfwlDDtF8DdeJY+MDaVUW7VewXRbvfY83YaKr7Rx+AzHq7OarfSjyPj/7qhKfgMbVmI0NQsZQiQ==",
+      "dev": true,
+      "dependencies": {
+        "@microsoft/applicationinsights-common": "2.7.2",
+        "@microsoft/applicationinsights-core-js": "2.7.2",
+        "@microsoft/applicationinsights-shims": "2.0.0",
+        "@microsoft/dynamicproto-js": "^1.1.4"
+      },
+      "peerDependencies": {
+        "tslib": "*"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-channel-js": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-2.7.2.tgz",
+      "integrity": "sha512-ypAVZbeKHY7ubeXdOSSPA1o07Dat2ZrNFB50vnFH0WvHRyqbgiYfu6hLURmeTwsjBCU2G5+OtbV0sqccKsR5vw==",
+      "dev": true,
+      "dependencies": {
+        "@microsoft/applicationinsights-common": "2.7.2",
+        "@microsoft/applicationinsights-core-js": "2.7.2",
+        "@microsoft/applicationinsights-shims": "2.0.0",
+        "@microsoft/dynamicproto-js": "^1.1.4"
+      },
+      "peerDependencies": {
+        "tslib": "*"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-common": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-2.7.2.tgz",
+      "integrity": "sha512-czlDjvgCGJ+l6iOLjxQytXI40sY9RHqouPqnb4ytM4xExAkrOdBonAVsCWBSYPsrAw5zyv7F1pKYeBLq3uGRnQ==",
+      "dev": true,
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "2.7.2",
+        "@microsoft/applicationinsights-shims": "2.0.0",
+        "@microsoft/dynamicproto-js": "^1.1.4"
+      },
+      "peerDependencies": {
+        "tslib": "*"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-core-js": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.7.2.tgz",
+      "integrity": "sha512-XV0ibH3RJRcKJiu50BS9EZ7izkx4nP13AKksd9kwbIifibaBFFofZ2RjuNO65e9pcPxuJVy6VwCeyCgW1i9zyw==",
+      "dev": true,
+      "dependencies": {
+        "@microsoft/applicationinsights-shims": "2.0.0",
+        "@microsoft/dynamicproto-js": "^1.1.4"
+      },
+      "peerDependencies": {
+        "tslib": "*"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-dependencies-js": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-dependencies-js/-/applicationinsights-dependencies-js-2.7.2.tgz",
+      "integrity": "sha512-tD7B869k3J26Zou4YUmHb6ehXOu8fd7vigyztewlCpCUeDYnfvipQRh96Smz7LeCLaSnUz6K2qYXALBQIwMXYQ==",
+      "dev": true,
+      "dependencies": {
+        "@microsoft/applicationinsights-common": "2.7.2",
+        "@microsoft/applicationinsights-core-js": "2.7.2",
+        "@microsoft/applicationinsights-shims": "2.0.0",
+        "@microsoft/dynamicproto-js": "^1.1.4"
+      },
+      "peerDependencies": {
+        "tslib": "*"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-properties-js": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-properties-js/-/applicationinsights-properties-js-2.7.2.tgz",
+      "integrity": "sha512-Yis0wrxUwpIq7Ih91+4vssehqgpc12T0j2/z2d+fZzfOv8pL0ti4ZmeCAjXPUZfoIAJMVtv/Q351Z8f0JX3uEw==",
+      "dev": true,
+      "dependencies": {
+        "@microsoft/applicationinsights-common": "2.7.2",
+        "@microsoft/applicationinsights-core-js": "2.7.2",
+        "@microsoft/applicationinsights-shims": "2.0.0",
+        "@microsoft/dynamicproto-js": "^1.1.4"
+      },
+      "peerDependencies": {
+        "tslib": "*"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-shims": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-2.0.0.tgz",
+      "integrity": "sha512-OaKew7f7acuNFgKYjMSPrRTRQi93xUyONWeeCeBlJSx7oRNJaL0TqbTvW6j5GHnSr3mhinPtAQ+rCQWASBnOrg==",
+      "dev": true
+    },
+    "node_modules/@microsoft/applicationinsights-web": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web/-/applicationinsights-web-2.7.2.tgz",
+      "integrity": "sha512-0tiuB38lqzARs81OV039H/x3pQFKN+llWz05TjukJ7K32x9syzx2Be6hGXbB4Q3a559s/N8ewn/82HtCVGGDOg==",
+      "dev": true,
+      "dependencies": {
+        "@microsoft/applicationinsights-analytics-js": "2.7.2",
+        "@microsoft/applicationinsights-channel-js": "2.7.2",
+        "@microsoft/applicationinsights-common": "2.7.2",
+        "@microsoft/applicationinsights-core-js": "2.7.2",
+        "@microsoft/applicationinsights-dependencies-js": "2.7.2",
+        "@microsoft/applicationinsights-properties-js": "2.7.2",
+        "@microsoft/applicationinsights-shims": "2.0.0",
+        "@microsoft/dynamicproto-js": "^1.1.4"
+      },
+      "peerDependencies": {
+        "tslib": "*"
+      }
+    },
+    "node_modules/@microsoft/dynamicproto-js": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-1.1.4.tgz",
+      "integrity": "sha512-Ot53G927ykMF8cQ3/zq4foZtdk+Tt1YpX7aUTHxBU7UHNdkEiBvBfZSq+rnlUmKCJ19VatwPG4mNzvcGpBj4og==",
+      "dev": true
     },
     "node_modules/@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
@@ -33469,6 +33588,103 @@
       "version": "1.6.22",
       "resolved": "https://registry.npmjs.org/@mdx-js/util/-/util-1.6.22.tgz",
       "integrity": "sha512-H1rQc1ZOHANWBvPcW+JpGwr+juXSxM8Q8YCkm3GhZd8REu1fHR3z99CErO1p9pkcfcxZnMdIZdIsXkOHY0NilA==",
+      "dev": true
+    },
+    "@microsoft/applicationinsights-analytics-js": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-analytics-js/-/applicationinsights-analytics-js-2.7.2.tgz",
+      "integrity": "sha512-f3I1pj/0e2BtfwlDDtF8DdeJY+MDaVUW7VewXRbvfY83YaKr7Rx+AzHq7OarfSjyPj/7qhKfgMbVmI0NQsZQiQ==",
+      "dev": true,
+      "requires": {
+        "@microsoft/applicationinsights-common": "2.7.2",
+        "@microsoft/applicationinsights-core-js": "2.7.2",
+        "@microsoft/applicationinsights-shims": "2.0.0",
+        "@microsoft/dynamicproto-js": "^1.1.4"
+      }
+    },
+    "@microsoft/applicationinsights-channel-js": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-2.7.2.tgz",
+      "integrity": "sha512-ypAVZbeKHY7ubeXdOSSPA1o07Dat2ZrNFB50vnFH0WvHRyqbgiYfu6hLURmeTwsjBCU2G5+OtbV0sqccKsR5vw==",
+      "dev": true,
+      "requires": {
+        "@microsoft/applicationinsights-common": "2.7.2",
+        "@microsoft/applicationinsights-core-js": "2.7.2",
+        "@microsoft/applicationinsights-shims": "2.0.0",
+        "@microsoft/dynamicproto-js": "^1.1.4"
+      }
+    },
+    "@microsoft/applicationinsights-common": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-2.7.2.tgz",
+      "integrity": "sha512-czlDjvgCGJ+l6iOLjxQytXI40sY9RHqouPqnb4ytM4xExAkrOdBonAVsCWBSYPsrAw5zyv7F1pKYeBLq3uGRnQ==",
+      "dev": true,
+      "requires": {
+        "@microsoft/applicationinsights-core-js": "2.7.2",
+        "@microsoft/applicationinsights-shims": "2.0.0",
+        "@microsoft/dynamicproto-js": "^1.1.4"
+      }
+    },
+    "@microsoft/applicationinsights-core-js": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.7.2.tgz",
+      "integrity": "sha512-XV0ibH3RJRcKJiu50BS9EZ7izkx4nP13AKksd9kwbIifibaBFFofZ2RjuNO65e9pcPxuJVy6VwCeyCgW1i9zyw==",
+      "dev": true,
+      "requires": {
+        "@microsoft/applicationinsights-shims": "2.0.0",
+        "@microsoft/dynamicproto-js": "^1.1.4"
+      }
+    },
+    "@microsoft/applicationinsights-dependencies-js": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-dependencies-js/-/applicationinsights-dependencies-js-2.7.2.tgz",
+      "integrity": "sha512-tD7B869k3J26Zou4YUmHb6ehXOu8fd7vigyztewlCpCUeDYnfvipQRh96Smz7LeCLaSnUz6K2qYXALBQIwMXYQ==",
+      "dev": true,
+      "requires": {
+        "@microsoft/applicationinsights-common": "2.7.2",
+        "@microsoft/applicationinsights-core-js": "2.7.2",
+        "@microsoft/applicationinsights-shims": "2.0.0",
+        "@microsoft/dynamicproto-js": "^1.1.4"
+      }
+    },
+    "@microsoft/applicationinsights-properties-js": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-properties-js/-/applicationinsights-properties-js-2.7.2.tgz",
+      "integrity": "sha512-Yis0wrxUwpIq7Ih91+4vssehqgpc12T0j2/z2d+fZzfOv8pL0ti4ZmeCAjXPUZfoIAJMVtv/Q351Z8f0JX3uEw==",
+      "dev": true,
+      "requires": {
+        "@microsoft/applicationinsights-common": "2.7.2",
+        "@microsoft/applicationinsights-core-js": "2.7.2",
+        "@microsoft/applicationinsights-shims": "2.0.0",
+        "@microsoft/dynamicproto-js": "^1.1.4"
+      }
+    },
+    "@microsoft/applicationinsights-shims": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-2.0.0.tgz",
+      "integrity": "sha512-OaKew7f7acuNFgKYjMSPrRTRQi93xUyONWeeCeBlJSx7oRNJaL0TqbTvW6j5GHnSr3mhinPtAQ+rCQWASBnOrg==",
+      "dev": true
+    },
+    "@microsoft/applicationinsights-web": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web/-/applicationinsights-web-2.7.2.tgz",
+      "integrity": "sha512-0tiuB38lqzARs81OV039H/x3pQFKN+llWz05TjukJ7K32x9syzx2Be6hGXbB4Q3a559s/N8ewn/82HtCVGGDOg==",
+      "dev": true,
+      "requires": {
+        "@microsoft/applicationinsights-analytics-js": "2.7.2",
+        "@microsoft/applicationinsights-channel-js": "2.7.2",
+        "@microsoft/applicationinsights-common": "2.7.2",
+        "@microsoft/applicationinsights-core-js": "2.7.2",
+        "@microsoft/applicationinsights-dependencies-js": "2.7.2",
+        "@microsoft/applicationinsights-properties-js": "2.7.2",
+        "@microsoft/applicationinsights-shims": "2.0.0",
+        "@microsoft/dynamicproto-js": "^1.1.4"
+      }
+    },
+    "@microsoft/dynamicproto-js": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-1.1.4.tgz",
+      "integrity": "sha512-Ot53G927ykMF8cQ3/zq4foZtdk+Tt1YpX7aUTHxBU7UHNdkEiBvBfZSq+rnlUmKCJ19VatwPG4mNzvcGpBj4og==",
       "dev": true
     },
     "@mrmlnc/readdir-enhanced": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@babel/core": "^7.16.5",
     "@lhci/cli": "^0.8.1",
+    "@microsoft/applicationinsights-web": "^2.7.2",
     "@storybook/builder-webpack5": "~6.3.12",
     "@storybook/html": "~6.3.12",
     "@storybook/manager-webpack5": "~6.3.12",

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -19,6 +19,12 @@ class App extends View {
   // PROPERTIES
 
   /**
+   * A reference to the Azure App Insights SDK (production only).
+   * @type {Object}
+   */
+  appInsights;
+
+  /**
    * A reference to the local database module.
    * @type {Database}
    */
@@ -57,6 +63,12 @@ class App extends View {
    * @type {Map}
    */
   pages = new Map;
+
+  /**
+   * A boolean indicating whether the app is currently running on production.
+   * @type {Boolean}
+   */
+  production = location.hostname === `app.digitallinguistics.io`;
 
   /**
    * An object for persisting app/user settings. Saves to Local Storage.
@@ -160,6 +172,10 @@ class App extends View {
 
     this.announce(`${ page } page`);
 
+    if (this.production && navigator.onLine) {
+      this.appInsights.trackPageView({ name: page });
+    }
+
   }
 
   /**
@@ -171,7 +187,16 @@ class App extends View {
     this.nav.render(this.settings.page, { open: this.settings.navOpen });
     this.displayPage(this.settings.page); // async
     this.addEventListeners();
+    await this.initializeAppInsights();
     return this.el;
+  }
+
+  async initializeAppInsights() {
+    if (this.production) {
+      const { appInsights } = await import(`../services/AppInsights.js`);
+      this.appInsights = appInsights;
+      this.appInsights.loadAppInsights();
+    }
   }
 
   /**

--- a/src/services/AppInsights.js
+++ b/src/services/AppInsights.js
@@ -1,0 +1,11 @@
+import { ApplicationInsights } from '@microsoft/applicationinsights-web';
+
+const connectionString = `InstrumentationKey=38a57ef0-6f19-41e8-9b92-e598226f8f38;IngestionEndpoint=https://westus2-2.in.applicationinsights.azure.com/`;
+
+const appInsights = new ApplicationInsights({
+  config: {
+    connectionString,
+  },
+});
+
+export { appInsights };


### PR DESCRIPTION
**Related Issue:**

closes #68

**Description of Changes**

This PR adds analytics in the form of Azure Application Insights. The only analytics currently being tracked, aside from the default ones (user, session) is page views. Each time `app.displayPage()` is called, a data point is sent to AppInsights with the page name.

The App Insights module only loads on production, and a data point is only sent when the user is online.